### PR TITLE
Refactor Calibration delay and Stop Pulse value

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -16,6 +16,8 @@ calib	KEYWORD2
 arm		KEYWORD2
 stop	KEYWORD2
 speed	KEYWORD2
+setCalibrationDelay	KEYWORD2
+setStopPulse	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/keywords.txt
+++ b/keywords.txt
@@ -13,7 +13,7 @@ ESC	KEYWORD1
 #######################################
 
 calib	KEYWORD2
-arm		KEYWORD2
+arm	KEYWORD2
 stop	KEYWORD2
 speed	KEYWORD2
 setCalibrationDelay	KEYWORD2
@@ -22,4 +22,4 @@ setStopPulse	KEYWORD2
 #######################################
 # Constants (LITERAL1)
 #######################################
-ESC_CAL_DELAY	KEYWORD3
+ESC_CAL_DELAY	LITERAL1

--- a/keywords.txt
+++ b/keywords.txt
@@ -22,4 +22,3 @@ setStopPulse	KEYWORD2
 #######################################
 # Constants (LITERAL1)
 #######################################
-ESC_CAL_DELAY	LITERAL1

--- a/src/ESC.cpp
+++ b/src/ESC.cpp
@@ -71,7 +71,7 @@ void ESC::speed(int outputESC)
  * Get the current calibration delay in miliseconds
  *
  */
-uint32_t getCalibrationDelay(void)
+uint32_t ESC::getCalibrationDelay(void)
 {
 	return calibrationDelay;
 }
@@ -80,7 +80,7 @@ uint32_t getCalibrationDelay(void)
  * Set the current calibration delay in miliseconds
  *
  */
-void setCalibrationDelay(uint32_t calibration_delay)
+void ESC::setCalibrationDelay(uint32_t calibration_delay)
 {
 	calibrationDelay = calibration_delay;
 }
@@ -89,7 +89,7 @@ void setCalibrationDelay(uint32_t calibration_delay)
  * Get the current Stop pulse in microseconds
  *
  */
-uint32_t getStopPulse(void)
+uint32_t ESC::getStopPulse(void)
 {
 	return stopPulse;
 }
@@ -98,7 +98,7 @@ uint32_t getStopPulse(void)
  * Set the current Stop pulse in microseconds
  *
  */
-void setStopPulse(uint32_t stop_pulse)
+void ESC::setStopPulse(uint32_t stop_pulse)
 {
 	stopPulse = stop_pulse;
 }

--- a/src/ESC.cpp
+++ b/src/ESC.cpp
@@ -32,9 +32,9 @@ void ESC::calib(void)
 {
 	myESC.attach(oPin);  			// attaches the ESC on pin oPin to the ESC object
 	myESC.writeMicroseconds(oMax);
-		delay(ESC_CAL_DELAY);
+		delay(calibrationDelay);
 	myESC.writeMicroseconds(oMin);
-		delay(ESC_CAL_DELAY);
+		delay(calibrationDelay);
 	arm();
 }
 
@@ -54,7 +54,7 @@ void ESC::arm(void)
  */
 void ESC::stop(void)
 {
-	myESC.writeMicroseconds (ESC_STOP_PULSE);
+	myESC.writeMicroseconds (stopPulse);
 }
 
 /*

--- a/src/ESC.cpp
+++ b/src/ESC.cpp
@@ -1,14 +1,15 @@
-/* Electronic Speed Controller (ESC) - Library */
-
 /*
-	
-*/
+ * Electronic Speed Controller (ESC) - Library
+ *
+ *
+ */
 
 #include "ESC.h"
 
 // < Constructor >
-/* Sets the proper pin to output.
-*/
+/*
+ * Sets the proper pin to output.
+ */
 ESC::ESC(byte ESC_pin, int outputMin, int outputMax, int armVal)
 {
 	oPin = ESC_pin;
@@ -23,9 +24,10 @@ ESC::~ESC()
 	// Nothing to destruct
 }
 
-// calib
-/* Calibrate the maximum and minimum PWM signal the ESC is expecting
-*/
+/*
+ * Calibrate the maximum and minimum PWM signal the ESC is expecting
+ * depends on the outputMin, outputMax values from the constructor
+ */
 void ESC::calib(void)
 {
 	myESC.attach(oPin);  			// attaches the ESC on pin oPin to the ESC object
@@ -36,17 +38,67 @@ void ESC::calib(void)
 	arm();
 }
 
+/*
+ * Sent a signal to Arm the ESC
+ * depends on the Arming value from the constructor
+ */
 void ESC::arm(void)
 {
 	myESC.attach(oPin);  			// attaches the ESC on pin oPin to the ESC object
 	myESC.writeMicroseconds (oArm);
 }
+
+/*
+ * Sent a signal to stop the ESC
+ * depends on the ESC stop pulse value
+ */
 void ESC::stop(void)
 {
 	myESC.writeMicroseconds (ESC_STOP_PULSE);
 }
+
+/*
+ * Sent a signal to set the ESC speed
+ * depends on the calibration minimum and maximum values
+ */
 void ESC::speed(int outputESC)
 {
 	oESC = constrain(outputESC, oMin, oMax);
 	myESC.writeMicroseconds(oESC);
+}
+
+/*
+ * Get the current calibration delay in miliseconds
+ *
+ */
+uint32_t getCalibrationDelay(void)
+{
+	return calibrationDelay;
+}
+
+/*
+ * Set the current calibration delay in miliseconds
+ *
+ */
+void setCalibrationDelay(uint32_t calibration_delay)
+{
+	calibrationDelay = calibration_delay;
+}
+
+/*
+ * Get the current Stop pulse in microseconds
+ *
+ */
+uint32_t getStopPulse(void)
+{
+	return stopPulse;
+}
+
+/*
+ * Set the current Stop pulse in microseconds
+ *
+ */
+void setStopPulse(uint32_t stop_pulse)
+{
+	stopPulse = stop_pulse;
 }

--- a/src/ESC.cpp
+++ b/src/ESC.cpp
@@ -68,30 +68,12 @@ void ESC::speed(int outputESC)
 }
 
 /*
- * Get the current calibration delay in miliseconds
- *
- */
-uint32_t ESC::getCalibrationDelay(void)
-{
-	return calibrationDelay;
-}
-
-/*
  * Set the current calibration delay in miliseconds
  *
  */
 void ESC::setCalibrationDelay(uint32_t calibration_delay)
 {
 	calibrationDelay = calibration_delay;
-}
-
-/*
- * Get the current Stop pulse in microseconds
- *
- */
-uint32_t ESC::getStopPulse(void)
-{
-	return stopPulse;
 }
 
 /*

--- a/src/ESC.h
+++ b/src/ESC.h
@@ -24,9 +24,7 @@ class ESC
 		void arm(void);
 		void stop(void);
 		void speed(int ESC_val);
-		uint32_t getCalibrationDelay(void);
 		void setCalibrationDelay(uint32_t calibration_delay);
-		uint32_t getStopPulse(void);
 		void setStopPulse(uint32_t stop_pulse);
 
 	private:
@@ -42,8 +40,6 @@ class ESC
 		uint32_t calibrationDelay = 8000;	// Calibration delay (milisecond)
 		uint32_t stopPulse = 500;	// Stop pulse (microseconds)
 		Servo myESC;		// create servo object to control an ESC
-
-
 };
 
 #endif

--- a/src/ESC.h
+++ b/src/ESC.h
@@ -1,7 +1,7 @@
-/* Electronic Speed Controller (ESC) - Library */
-
 /*
-
+ * Electronic Speed Controller (ESC) - Library
+ *
+ *
 */
 
 #ifndef ESC_Library
@@ -14,8 +14,6 @@
 #endif
 
 #include <Servo.h>				// Including the Servo library
-#define ESC_CAL_DELAY	(8000)	// Calibration delay (milisecond)
-#define ESC_STOP_PULSE	(500)	//
 
 class ESC
 {
@@ -26,17 +24,23 @@ class ESC
 		void arm(void);
 		void stop(void);
 		void speed(int ESC_val);
-	
+		uint32_t getCalibrationDelay(void);
+		void setCalibrationDelay(uint32_t calibration_delay);
+		uint32_t getStopePulse(void);
+		void setStopPulse(uint32_t stop_pulse);
+
 	private:
 	// < Local attributes >
 		// Hardware
 		byte oPin;			// ESC output Pin
-		
+
 		// Calibration
 		int oMin = 1000; 
 		int oMax = 2000;
 		int oESC = 1000;
 		int oArm = 500;
+		int calibrationDelay = 8000;	// Calibration delay (milisecond)
+		int stopPulse = 500;	// stop pulse(milisecond)
 		Servo myESC;		// create servo object to control an ESC
 
 

--- a/src/ESC.h
+++ b/src/ESC.h
@@ -40,7 +40,7 @@ class ESC
 		int oESC = 1000;
 		int oArm = 500;
 		uint32_t calibrationDelay = 8000;	// Calibration delay (milisecond)
-		uint32_t stopPulse = 500;	// Stop pulse(milisecond)
+		uint32_t stopPulse = 500;	// Stop pulse (microseconds)
 		Servo myESC;		// create servo object to control an ESC
 
 

--- a/src/ESC.h
+++ b/src/ESC.h
@@ -26,7 +26,7 @@ class ESC
 		void speed(int ESC_val);
 		uint32_t getCalibrationDelay(void);
 		void setCalibrationDelay(uint32_t calibration_delay);
-		uint32_t getStopePulse(void);
+		uint32_t getStopPulse(void);
 		void setStopPulse(uint32_t stop_pulse);
 
 	private:
@@ -39,8 +39,8 @@ class ESC
 		int oMax = 2000;
 		int oESC = 1000;
 		int oArm = 500;
-		int calibrationDelay = 8000;	// Calibration delay (milisecond)
-		int stopPulse = 500;	// stop pulse(milisecond)
+		uint32_t calibrationDelay = 8000;	// Calibration delay (milisecond)
+		uint32_t stopPulse = 500;	// Stop pulse(milisecond)
 		Servo myESC;		// create servo object to control an ESC
 
 


### PR DESCRIPTION
Calibration delay and the Stop Pulse value should be refactored with Setter options
Currently, these values are library constants `ESC_CAL_DELAY` and `ESC_STOP_PULSE` but are something that the user may need to change for their specific ESC.

Updated some of the library comments