### PR TITLE
Updated library inclusion for ESp32Servo

### DIFF
--- a/src/ESC.h
+++ b/src/ESC.h
@@ -13,7 +13,11 @@
 	#include "WProgram.h"
 #endif
 
-#include <Servo.h>				// Including the Servo library
+#if (defined(ESP32) || defined(ARDUINO_ARCH_ESP32))
+	#include <ESP32Servo.h>                         // Including Library from https://github.com/jkb-git/ESP32Servo	
+#else
+	#include <Servo.h>				// Including the Servo library
+#endif
 
 class ESC
 {


### PR DESCRIPTION
This PR is to add support for ESP32 Arch Type: ESP and ARDUINO_ARCH_ESP32. To perform this, we need to include Library from https://github.com/jkb-git/ESP32Servo. This change assumes the ESP32Servo is already downloaded into the Arduino libraries folder

```
In file included from <path>/Arduino/libraries/RC_ESC/src/ESC.h:16:0,
                 from <path>/Arduino/mysketch/mysketch.ino:5:
<some random path>/T/AppTranslocation//d/Arduino.app/Contents/Java/libraries/Servo/src/Servo.h:77:2: error: #error "This library only supports boards with an AVR, SAM, SAMD, NRF52 or STM32F4 processor."
 #error "This library only supports boards with an AVR, SAM, SAMD, NRF52 or STM32F4 processor."
  ^
exit status 1
Error compiling for board ESP32 Dev Module.
```